### PR TITLE
refact(packages) execute script from node_modules/.bin/ directly

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,12 +11,12 @@
   },
   "licenses": [],
   "scripts": {
-    "postinstall": "node node_modules/.bin/bower install --d",
-    "start": "node node_modules/.bin/webpack-dev-server --content-base src/ --hot --port 1337 --inline --devtool eval --progress --colors",
-    "dist": "node node_modules/grunt-cli/bin/grunt default",
+    "postinstall": "bower install --d",
+    "start": "webpack-dev-server --content-base src/ --hot --port 1337 --inline --devtool eval --progress --colors",
+    "dist": "grunt default",
     "test": "karma start --singleRun false",
     "testOnce": "karma start",
-    "checkStyle": "node ./node_modules/jscs/bin/jscs ./src/*.js --config=./js-styleguide.jscsrc"
+    "checkStyle": "jscs ./src/*.js --config=./js-styleguide.jscsrc"
   },
   "dependencies": {
     "angular": "1.4.8",


### PR DESCRIPTION
When executing a script using `npm run foo`, npm adds `./node_modules/.bin` to the `PATH`. This means that it is unnecessary to mention `node_modules/.bin/` again when executing the scripts.

Documentation: https://docs.npmjs.com/cli/run-script